### PR TITLE
reset now removes the old ozone directory

### DIFF
--- a/playbook/ozone/scripts/reset_node.sh
+++ b/playbook/ozone/scripts/reset_node.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 rm -rf /hadoop/app/ozone/logs/*
 rm -rf /hadoop/ozone/data/disk*/*
-rm -rf /hadoop/app/ozone/data
+rm -rf /hadoop/app
 rm -rf /tmp/hadoop-*
 


### PR DESCRIPTION
without this fix, the new install coexisted with the old version and didn't work correctly